### PR TITLE
Added mike build and deploy workflow for git-main

### DIFF
--- a/.github/workflows/mike-deploy.yml
+++ b/.github/workflows/mike-deploy.yml
@@ -1,0 +1,42 @@
+name: Mike build and deploy
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: mike deploy main on gh-pages
+    steps:
+      - name: git-checkout
+        uses: actions/checkout@v2
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.MIKE_PAT }}
+
+      - name: Set up Python 3.x
+        uses: actions/setup-python@v1
+        with:
+          python-version: '3.x'
+          architecture: 'x64'
+
+      - name: Display Python version
+        run: python -c "import sys; print(sys.version)"
+ 
+      - name: Install dependencies
+        run: |
+          cd $GITHUB_WORKSPACE 
+          pip install -r requirements.txt
+
+      - name: Configure Git user
+        run: |
+          git config --local user.email "github-actions[bot]@users.noreply.github.com"
+          git config --local user.name "github-actions[bot]"
+
+      - name: Build and deploy
+        run: |
+          cd $GITHUB_WORKSPACE
+          mike deploy --push git-main

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ROSflight Documentation
 
-[![Documentation](https://github.com/rosflight/rosflight_documentation/actions/workflows/docs.yml/badge.svg)](https://github.com/rosflight/rosflight_documentation/actions/workflows/docs.yml)
+[![Documentation](https://github.com/rosflight/rosflight_documentation/actions/workflows/docs.yml/badge.svg)](https://github.com/rosflight/rosflight_documentation/actions/workflows/docs.yml) [![Mike build and deploy](https://github.com/rosflight/rosflight_docs/actions/workflows/mike-deploy.yml/badge.svg)](https://github.com/rosflight/rosflight_docs/actions/workflows/mike-deploy.yml)
 
 This repository contains the source files for the documentation portion of the ROSflight website.
 
@@ -41,6 +41,6 @@ $$ E = mc^2 $$
 
 ## Publishing changes onto the docs.rosflight.org website
 
-To publish changes back onto the website, use the command `mike deploy --push [version]`, replacing `[version]` with the version of the documentation you want to push to. This will then update the build file on the `gh-pages` branch with the changes.
+Versioning is handled with the Python utility mike. See https://github.com/jimporter/mike for more information on using mike.
 
-See https://github.com/jimporter/mike for more information on using mike.
+New versions of documentation will need to be deployed and pushed manually for changes to be reflected on the webpage. git-main and other git documentation versions will update automatically when their respective branches are updated.


### PR DESCRIPTION
Adding a git-main page to the documentation web page would be very useful, so that as changes are pushed to the main branch they can be immediately viewed on the web page. To automate this process, I've added a github actions workflow that will do exactly that: build git-main with mike and then push it to gh-pages, where the changes will then get pulled by the server. Since gh-pages is a protected branch, I needed to setup and use a personal access token.

Currently MIKE_PAT is using a personal access token of mine, but setting up a rosflight bot account with access only to that branch would be a safer solution. 