### PR TITLE
update tutorial to point to correct parameter file

### DIFF
--- a/docs/user-guide/tutorials/manually-flying-rosflight-sim.md
+++ b/docs/user-guide/tutorials/manually-flying-rosflight-sim.md
@@ -43,7 +43,7 @@ We will load parameters from a file.
 1. Load the multirotor or fixedwing parameter YAML files:
   ```bash
   # For multirotor
-  ros2 service call /param_load_from_file rosflight_msgs/srv/ParamFile "{filename: $(pwd)/multirotor_firmware.yaml}"
+  ros2 service call /param_load_from_file rosflight_msgs/srv/ParamFile "{filename: $(pwd)/multirotor_firmware/multirotor_combined.yaml}"
 
   # For fixedwing
   ros2 service call /param_load_from_file rosflight_msgs/srv/ParamFile "{filename: $(pwd)/fixedwing_firmware.yaml}"

--- a/docs/user-guide/tutorials/tuning-performance-in-sim.md
+++ b/docs/user-guide/tutorials/tuning-performance-in-sim.md
@@ -185,7 +185,7 @@ PID_ROLL_ANG_D: 0.2
 
 These gains (with values similar to these) are already set, so you don't technically need to set them.
 
-These get loaded at launch time to the firmware from the `/path/to/rosflight_ws/src/rosflight_ros_pkgs/rosflight_sim/params/multirotor_firmware.yaml` file.
+These get loaded at launch time to the firmware from the `/path/to/rosflight_ws/src/rosflight_ros_pkgs/rosflight_sim/params/multirotor_firmware/multirotor_commbined.yaml` file.
 You can change them in the launch file and relaunch, but that is a pain.
 We'll use RQT and the ROS2 parameter system to dynamically reconfigure those parameters.
 


### PR DESCRIPTION
Updates tutorials to point to correct multirotor firmware parameter file based on changes from rosflight/rosflight_ros_pkgs#218