### PR TITLE
documentation typo fixes

### DIFF
--- a/docs/user-guide/installation/installation-hardware.md
+++ b/docs/user-guide/installation/installation-hardware.md
@@ -36,10 +36,10 @@ Unsuprisingly, [ROS2](https://docs.ros.org/en/humble/index.html) is a required d
 You can do this with a native installation of ROS2 or by following the [ROSflight Docker guide](./using-docker-with-rosflight.md).
 To install ROS2 natively, check out the official [ROS2 Installation](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) page for details.
 
-If you don't plan to run simulations or GUI applications on your companion computer, `ros-humble-ros-base` can be used instead of `ros-humble-desktop`.
+If you don't plan to run simulations or GUI applications on your companion computer, `ros-<ros-distro>-ros-base` can be used instead of `ros-<ros-distro>-desktop`.
 
 !!! note
-    ROSflight currently officially supports only **ROS2 Humble**, running on Ubuntu 22.04.
+    ROSflight currently officially supports only LTS versions of ROS2, so **ROS2 Humble** running on Ubuntu 22.04 or **ROS2 Jazzy** running on Ubuntu 24.04.
     If you want to run a different version of ROS2, some of the below instructions may not work.
     [ROS2 Rolling](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html) is not fixed-release and is therefore not officially supported. 
 
@@ -76,7 +76,7 @@ Do the following on your companion computer.
     !!! warning
         Make sure you have properly sourced [the ROS2 environment](https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html) in the terminal you are working in, or the `rosdep` and `colcon` commands will fail.
         ```bash
-        source /opt/ros/humble/setup.bash
+        source /opt/ros/<ros-distro>/setup.bash
         ```
 
     !!! tip

--- a/docs/user-guide/installation/installation-sim.md
+++ b/docs/user-guide/installation/installation-sim.md
@@ -23,10 +23,10 @@ Unsuprisingly, [ROS2](https://docs.ros.org/en/humble/index.html) is a required d
 You can do this with a native installation of ROS2 or by following the [ROSflight Docker guide](./using-docker-with-rosflight.md).
 To install ROS2 natively, check out the official [ROS2 Installation](https://docs.ros.org/en/humble/Installation/Ubuntu-Install-Debians.html) page for details.
 
-If you don't plan to run simulations or GUI applications on your companion computer, `ros-humble-ros-base` can be used instead of `ros-humble-desktop`.
+If you don't plan to run simulations or GUI applications on your companion computer, `ros-<ros-distro>-ros-base` can be used instead of `ros-<ros-distro>-desktop`.
 
 !!! note
-    ROSflight currently officially supports only **ROS2 Humble**, running on Ubuntu 22.04.
+    ROSflight currently officially supports only LTS versions of ROS2, so **ROS2 Humble** running on Ubuntu 22.04 or **ROS2 Jazzy** running on Ubuntu 24.04.
     If you want to run a different version of ROS2, some of the below instructions may not work.
     [ROS2 Rolling](https://docs.ros.org/en/rolling/Installation/Ubuntu-Install-Debians.html) is not fixed-release and is therefore not officially supported. 
 
@@ -64,7 +64,7 @@ git clone https://github.com/rosflight/rosplane
     !!! warning
         Make sure you have properly sourced [the ROS2 environment](https://docs.ros.org/en/humble/Tutorials/Beginner-CLI-Tools/Configuring-ROS2-Environment.html) in the terminal you are working in, or the `rosdep` and `colcon` commands will fail.
         ```bash
-        source /opt/ros/humble/setup.bash
+        source /opt/ros/<ros-distro>/setup.bash
         ```
     
     ```bash
@@ -106,7 +106,8 @@ colcon build
 1. Add the source files to your `.bashrc` (so you don't have to source the files every time you open a terminal):
     ```bash
     # add the sourcing commands to your .bashrc. Replace bash with zsh if using zsh.
-    echo "source /opt/ros/humble/setup.bash" >> $HOME/.bashrc
+    # Replace <ros-distro> with your ROS2 distribution
+    echo "source /opt/ros/<ros-distro>/setup.bash" >> $HOME/.bashrc
     echo "source /path/to/rosflight_ws/install/setup.bash" >> $HOME/.bashrc
     ```
     Make sure to close your current terminal and open a new one after adding these commands to your `.bashrc` file.

--- a/docs/user-guide/tutorials/setting-up-roscopter-in-sim.md
+++ b/docs/user-guide/tutorials/setting-up-roscopter-in-sim.md
@@ -229,7 +229,7 @@ ros2 service call /path_planner/clear_waypoints std_srvs/srv/Trigger
 The structure of the `wp` field in the `roscopter_msgs/srv/AddWaypoint` service is the same as described above.
 The structure of the service can be seen using:
 ```bash
-ros2 interface show roscopter_msgs/srv/AddWayoint
+ros2 interface show roscopter_msgs/srv/AddWaypoint
 ```
 which will output:
 ```bash

--- a/docs/user-guide/tutorials/setting-up-rosflight-sim.md
+++ b/docs/user-guide/tutorials/setting-up-rosflight-sim.md
@@ -37,7 +37,8 @@ The ROSflight standalone simulator consists of several key components:
     First, ensure your ROS2 environment and ROSflight workspace are properly sourced:
 
     ```bash
-    source /opt/ros/humble/setup.bash
+    # Replace <ros-distro> with your ROS 2 distro (e.g. "humble" or "jazzy")
+    source /opt/ros/<ros-distro>/setup.bash
     source /path/to/rosflight_ws/install/setup.bash
     ```
 
@@ -163,7 +164,7 @@ Key topics include:
 ### Common Issues
 
 ??? warning "RViz Not Opening"
-    - Ensure you installed `ros-humble-desktop`, not `ros-humble-ros-base`
+    - Ensure you installed `ros-<ros-distro>-desktop`, not `ros-<ros-distro>-ros-base`, where `<ros-distro>` is the ROS 2 distro you installed
     - Check that you have a display environment (not running in headless mode)
 
 ??? warning "Simulation Crashes"

--- a/docs/user-guide/tutorials/tuning-performance-in-sim.md
+++ b/docs/user-guide/tutorials/tuning-performance-in-sim.md
@@ -89,7 +89,7 @@ ros2 launch rosflight_sim multirotor_init_firmware.launch.py
 
 # Terminal 3: Run ROScopter controller
 cd /path/to/rosflight_ws/src/roscopter/roscopter/params
-ros2 launch roscopter controller --ros-args --params-file $(pwd)/multirotor.yaml
+ros2 run roscopter controller --ros-args --params-file $(pwd)/multirotor.yaml
 
 # Terminal 4: Run the sim state transcriber node
 ros2 run roscopter_sim sim_state_transcriber
@@ -116,7 +116,7 @@ We'll use it to plot data live as we send control commands to the vehicle.
 Launching PlotJuggler:
 ```bash
 # Install PlotJuggler if not already installed
-sudo apt install ros-humble-plotjuggler-ros
+sudo apt install ros-<ros-distro>-plotjuggler-ros
 
 # Launch PlotJuggler
 ros2 run plotjuggler plotjuggler


### PR DESCRIPTION
This PR fixes some typos in the tutorials (closes #38 #37 )
It also fixes references about ROS2 humble being the only supported ROS2 distro.